### PR TITLE
Add :level-key to specify a different option for the level/severity which is required for GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ user> (timbre/info "Hello" :o (Object.))
     "o" : { }
   }
 }
+
+As a last resort, default println appender is used, if JSON serialization fails.
+
 ```
 
 Arguments can also be placed inline, instead of being put behind `:args` key.
@@ -95,9 +98,22 @@ user=> (timbre/with-context {:important-context "goes-here" :and :here} (timbre/
 ```
 
 
-As a last resort, default println appender is used, if JSON serialization fails.
+If you need to emit the log-level to a key other than `level`, you can supply the `level-key` arg
+
+```
+user=> (tas/install)
+user=> (timbre/info "test")
+{"timestamp":"2020-11-07T00:28:36Z","level":"info","thread":"main","msg":"test"}
+user=> (tas/install {:level-key :severity})
+user=> (timbre/info "test")
+{"timestamp":"2020-11-07T00:28:50Z","severity":"info","thread":"main","msg":"test"}
+```
 
 # Changelog
+
+2020-11-07 (0.1.3)
+
+* Support to change the level key from level to (eg severity to support GCP Logging)
 
 2020-11-03 (0.1.2)
 

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -53,7 +53,7 @@
   "Creates Timbre configuration map for JSON appender"
   ([]
    (json-appender {}))
-  ([{:keys [pretty inline-args?] :or {pretty false inline-args? false}}]
+  ([{:keys [pretty inline-args? level-key] :or {pretty false inline-args? false level-key :level}}]
    (let [object-mapper (object-mapper {:pretty pretty})
          println-appender (taoensso.timbre/println-appender)
          fallback-logger (:fn println-appender)]
@@ -62,7 +62,7 @@
       :min-level nil
       :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt context] :as data}]
             (let [log-map (handle-vargs {:timestamp instant
-                                         :level level
+                                         level-key level
                                          :thread (.getName (Thread/currentThread))}
                                         ?msg-fmt
                                         vargs
@@ -90,11 +90,14 @@
   `inline-args?` Place arguments on top level, instead of placing behing `args` field"
   ([]
    (install :info))
-  ([{:keys [level pretty inline-args?] :or {level :info
-                                            pretty false
-                                            inline-args? true}}]
+  ([{:keys [level pretty inline-args? level-key] :or {level :info
+                                                      level-key :level
+                                                      pretty false
+                                                      inline-args? true}}]
    (timbre/set-config! {:level level
-                        :appenders {:json (json-appender {:pretty pretty :inline-args? inline-args?})}})))
+                        :appenders {:json (json-appender {:pretty pretty 
+                                                          :inline-args? inline-args?
+                                                          :level-key level-key})}})))
 
 (defn log-success [request-method uri status]
   (timbre/info :method request-method :uri uri :status status))

--- a/test/timbre_json_appender/core_test.clj
+++ b/test/timbre_json_appender/core_test.clj
@@ -92,3 +92,20 @@
                                   (timbre/with-context {:test-context 123}
                                     (timbre/info :a 1)))))]
         (is (= 123 (:test-context log)))))))
+
+
+(deftest level-key-changes
+  (let [level-key-diff {:level :info :appenders {:json (sut/json-appender {})}}]
+    (testing "test key for info"
+      (let [log (parse-string (with-out-str (timbre/with-config level-key-diff (timbre/info "test"))))]
+        (is (= "info" (:level log)))))
+    (testing "test key for info"
+      (let [log (parse-string (with-out-str (timbre/with-config level-key-diff (timbre/warn "test"))))]
+        (is (= "warn" (:level log))))))
+  (let [level-key-diff {:level :info :appenders {:json (sut/json-appender {:level-key :severity})}}]
+    (testing "test key for info"
+      (let [log (parse-string (with-out-str (timbre/with-config level-key-diff (timbre/info "test"))))]
+        (is (= "info" (:severity log)))))
+    (testing "test key for info"
+      (let [log (parse-string (with-out-str (timbre/with-config level-key-diff (timbre/warn "test"))))]
+        (is (= "warn" (:severity log)))))))


### PR DESCRIPTION
GCP Logging seems to require level to be under the "severity" key in the json payload

https://stackoverflow.com/questions/43208878/how-does-stackdriver-logging-assert-the-severity-of-an-entry