### PR TITLE
Bump dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
- :deps {metosin/jsonista {:mvn/version "0.2.3"}
-        com.taoensso/timbre {:mvn/version "4.10.0"}}
+ :deps {metosin/jsonista {:mvn/version "0.3.1"}
+        com.taoensso/timbre {:mvn/version "5.1.2"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-521"}}}
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.830"}}}
            :pack {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                                 :sha "110ca11f853fa9dbb3f8eadba3c4176311bae4ac"}}
                   :main-opts ["-m"]}}}

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -73,7 +73,7 @@
                                   (assoc :ns ?ns-str)
                                   (assoc :file ?file)
                                   (assoc :line ?line))
-                            (and context inline-args?) 
+                            (and context inline-args?)
                             (merge context)
                             (and context (not inline-args?))
                             (update :args merge context))]
@@ -85,17 +85,17 @@
 (defn install
   "Installs json-appender as the sole appender for Timbre, options
 
-  `level`:       Timbre log level
+  `level`:       Timbre log level (deprecated, prefer min-level)
+  `min-level`:   Timbre log level
   `pretty`:      Pretty-print JSON
   `inline-args?` Place arguments on top level, instead of placing behing `args` field"
   ([]
    (install :info))
-  ([{:keys [level pretty inline-args? level-key] :or {level :info
-                                                      level-key :level
-                                                      pretty false
-                                                      inline-args? true}}]
-   (timbre/set-config! {:level level
-                        :appenders {:json (json-appender {:pretty pretty 
+  ([{:keys [level min-level pretty inline-args? level-key] :or {level-key :level
+                                                                pretty false
+                                                                inline-args? true}}]
+   (timbre/set-config! {:min-level (or min-level level :info)
+                        :appenders {:json (json-appender {:pretty pretty
                                                           :inline-args? inline-args?
                                                           :level-key level-key})}})))
 


### PR DESCRIPTION
Library changes:

Jsonista: https://github.com/metosin/jsonista/blob/master/CHANGELOG.md#031-2021-01-27
Timbre: major changes: https://github.com/ptaoussanis/timbre/releases/tag/v5.0.0, latest: https://github.com/ptaoussanis/timbre/releases/tag/v5.1.2

Adds the `min-level` argument to replace `level` for consistency with Timbre.