### PR TITLE
Allow custom filtering of fields using should-log-field-fn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A Timbre log invocation maps to JSON messages the following way:
 =>
 {"timestamp": "2019-07-03T10:00:08Z", # Always included
  "level": "error",                    # ditto
- "thread": nRepl-session-...",        # ditto
+ "thread": "nRepl-session-...",       # ditto
+ "hostname": "localhost",             # ditto
  "msg": "Action failure",             # An (optional) first argument
  "user-id": 1,                        # Keyword style arguments
  "err": {"via":[{"type":"...,         # When exception is logged, a Throwable->map presentation of the exception
@@ -50,6 +51,7 @@ user> (timbre/info "Hello" :user-id 1 :profile {:role :tester})
 {
   "timestamp" : "2019-07-03T10:23:38Z",
   "level" : "info",
+  "hostname": "localhost",
   "thread" : "nRepl-session-97b9389e-a563-4f0d-8b8a-f58050297092",
   "msg" : "Hello",
   "args" : {
@@ -137,6 +139,9 @@ user=> (tas/install)
 user=> (timbre/info "Hello" {:user-id 1})
 {"timestamp":"2021-03-26T15:05:16Z","level":"info","thread":"main","msg":"Hello","user-id":1}
 ```
+
+If you wish to change the default fields: `:hostname :thread :ns :file :line` which are logged a function: `:should-log-field-fn` with the signture `(field-name, timbre-data) -> boolean` can be provided which should return a boolean indicating whether to log the field.
+By default `tas/default-should-log-field-fn` is used. This only logs `:hostname` and `:thread` unless an error occurs, in which case `:ns`, `:file` and `:line` are also output.
 
 # Changelog
 

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clojure -A:test -m kaocha.runner "$@"
+clojure -A:test -M -m kaocha.runner "$@"

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -44,9 +44,14 @@
 (defn- merge-log-map [inline-args? log-map args]
   (if inline-args?
     (merge log-map args)
-    (assoc log-map :args args)))
+    (update log-map :args merge args)))
 
-(defn handle-vargs [log-map ?msg-fmt vargs inline-args?]
+(defn handle-vargs
+  "Handles varg parsing, adding the msg and the given context to the given log map.
+   
+   If inline-args is true, then the remaining vargs are added to :args,
+   otherwise they're inlined into the log-map."
+  [log-map ?msg-fmt vargs inline-args?]
   (cond
     ?msg-fmt (let [format-specifiers (count-format-specifiers ?msg-fmt)
                    log-map (assoc log-map :msg (String/format ?msg-fmt (to-array (take format-specifiers vargs))))]
@@ -57,34 +62,46 @@
                           log-map)]
             (merge-log-map inline-args? log-map args))))
 
+(defn default-should-log-field-fn
+  "Default function to determine whether to log fields.
+   
+   Logs all fields except :file :line and :ns which are only logged on error."
+  [field-name {:keys [?err] :as _data}]
+  (if (contains? #{:file :line :ns} field-name)
+    ?err
+    true))
+
 (defn json-appender
   "Creates Timbre configuration map for JSON appender"
   ([]
    (json-appender {}))
-  ([{:keys [pretty inline-args? level-key] :or {pretty false inline-args? false level-key :level}}]
+  ([{:keys [pretty inline-args? level-key should-log-field-fn] :or {pretty false inline-args? false level-key :level should-log-field-fn default-should-log-field-fn}}]
    (let [object-mapper (object-mapper {:pretty pretty})
          println-appender (taoensso.timbre/println-appender)
          fallback-logger (:fn println-appender)]
      {:enabled? true
       :async? false
       :min-level nil
-      :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt context] :as data}]
-            (let [log-map (handle-vargs {:timestamp instant
-                                         level-key level
-                                         :thread (.getName (Thread/currentThread))}
-                                        ?msg-fmt
-                                        vargs
-                                        inline-args?)
-                  log-map (cond-> log-map
-                            ?err (->
-                                  (assoc :err (Throwable->map ?err))
-                                  (assoc :ns ?ns-str)
-                                  (assoc :file ?file)
-                                  (assoc :line ?line))
-                            (and context inline-args?)
-                            (merge context)
-                            (and context (not inline-args?))
-                            (update :args merge context))]
+      :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context] :as data}]
+            (let [;; apply context prior to resolving vargs so specific log values override context values  
+                  base-log-map (cond
+                                 (and (not inline-args?) (seq context)) {:args context}
+                                 (and inline-args? (seq context)) context
+                                 :default {})
+                  log-map (-> (handle-vargs base-log-map
+                                            ?msg-fmt
+                                            vargs
+                                            inline-args?)
+                              ;; apply base fields last to ensure they have precedent over context and vargs
+                              (assoc :timestamp instant)
+                              (assoc level-key level)
+                              (cond->
+                               (should-log-field-fn :thread data) (assoc :thread (.getName (Thread/currentThread)))
+                               (should-log-field-fn :file data) (assoc :file ?file)
+                               (should-log-field-fn :line data) (assoc :line ?line)
+                               (should-log-field-fn :ns data) (assoc :ns ?ns-str)
+                               (should-log-field-fn :hostname data) (assoc :hostname (force hostname_))
+                               ?err (assoc :err (Throwable->map ?err))))]
               (try
                 (println (json/write-value-as-string log-map object-mapper))
                 (catch Throwable _
@@ -93,19 +110,22 @@
 (defn install
   "Installs json-appender as the sole appender for Timbre, options
 
-  `level`:       Timbre log level (deprecated, prefer min-level)
-  `min-level`:   Timbre log level
-  `pretty`:      Pretty-print JSON
-  `inline-args?` Place arguments on top level, instead of placing behing `args` field"
+  `level`:        Timbre log level (deprecated, prefer min-level)
+  `min-level`:    Timbre log level
+  `level-key`:    The key to use for log-level
+  `pretty`:       Pretty-print JSON
+  `inline-args?`: Place arguments on top level, instead of placing behing `args` field
+  `should-log-field-fn`: A function which determines whether to log the given top-level field.  Defaults to default-should-log-field-fn"
   ([]
    (install :info))
-  ([{:keys [level min-level pretty inline-args? level-key] :or {level-key :level
-                                                                pretty false
-                                                                inline-args? true}}]
+  ([{:keys [level min-level pretty inline-args? level-key should-log-field-fn] :or {level-key :level
+                                                                                    pretty false
+                                                                                    inline-args? true}}]
    (timbre/set-config! {:min-level (or min-level level :info)
                         :appenders {:json (json-appender {:pretty pretty
                                                           :inline-args? inline-args?
-                                                          :level-key level-key})}})))
+                                                          :level-key level-key
+                                                          :default-should-log-field-fn should-log-field-fn})}})))
 
 (defn log-success [request-method uri status]
   (timbre/info :method request-method :uri uri :status status))


### PR DESCRIPTION
This has the existing default behaviour, but also adds hostnames to the output logs.

e.g.

```clojure
(sut/json-appender {:should-log-field-fn (fn [field-name data]
                                           (if (contains? #{:hostname} field-name)
                                             false
                                             (sut/default-should-log-field-fn field-name data)))})
```

I originally just considered providing set, but this seemed more flexible. Currently `:args` can't be filtered, neither can `:timestamp` `:err` or `:log-level` (or a log level alias) as these seem somewhat essential.

_I don't love the name of the function at the mo'_

As part of this PR I also make changes to ensure precidence is respected for default fields, context and an individual log:

default fields -> individual log -> context

i.e. the caller can't override `timestamp` when using inline-args, and context is always overriden by a matching log argument.

Closes https://github.com/viesti/timbre-json-appender/issues/17