### PR TITLE
Adds pre-processor functionality for ex-info data map fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ user> (timbre/info "Hello" :user-id 1 :profile {:role :tester})
   }
 }
 
-user> (tas/install {:data-field-fn (fn [f] (when (instance? java.io.Serializable f) f))})
+user> (tas/install {:ex-data-field-fn (fn [f] (when (instance? java.io.Serializable f) f))})
 
 user> (timbre/error (ex-info "Hello" {:user-id 1 :not-serial (java.lang.ClassLoader/getSystemClassLoader)}))
 {"timestamp": "2021-10-03T17:09:00Z", "level": "error" ... "cause": "Hello", "data": {"user-id": 1, "not-serial": null}}}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ user> (timbre/info "Hello" :user-id 1 :profile {:role :tester})
     }
   }
 }
+
+user> (tas/install {:data-field-fn (fn [f] (when (instance? java.io.Serializable f) f))})
+
+user> (timbre/error (ex-info "Hello" {:user-id 1 :not-serial (java.lang.ClassLoader/getSystemClassLoader)}))
+{"timestamp": "2021-10-03T17:09:00Z", "level": "error" ... "cause": "Hello", "data": {"user-id": 1, "not-serial": null}}}
 ```
 
 Note the expected format:

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -71,6 +71,15 @@
     ?err
     true))
 
+(defn default-data-field-fn
+  "Default function to pre-process fields in data map. This default implementation simply passes the
+  field value through. A common use case might be to strip non-Serializable values from the data map.
+  While exceptions with non-Serializable fields won't prevent logging, they will prevent successful
+  JSON parsing and will use the fallback logger. A data-field-fn of `(fn [f] (when (instance? Serializable f) f))`
+  would replace the non-Serializable values with nils."
+  [f]
+  f)
+
 (def system-newline (System/getProperty "line.separator"))
 
 ;; Taken from timbre: https://github.com/ptaoussanis/timbre/commit/057b5a4c871752957e50c3eaf667c0517d56ca9a
@@ -79,24 +88,34 @@
   [x]
   (print (str x system-newline)) (flush))
 
+(defn- process-data-map [data-field-fn ex]
+  (when ex
+    (let [cause (process-data-map data-field-fn (ex-cause ex))]
+      (ex-info (ex-message ex)
+               (into {} (map (fn [[k v]] {k (data-field-fn v)}) (ex-data ex)))
+               cause))))
+
 (defn json-appender
   "Creates Timbre configuration map for JSON appender"
   ([]
    (json-appender {}))
-  ([{:keys [pretty inline-args? level-key msg-key should-log-field-fn]
+  ([{:keys [pretty inline-args? level-key msg-key should-log-field-fn data-field-fn]
      :or {pretty              false
           inline-args?        false
           level-key           :level
           msg-key             :msg
-          should-log-field-fn default-should-log-field-fn}}]
+          should-log-field-fn default-should-log-field-fn
+          data-field-fn       default-data-field-fn}}]
    (let [object-mapper (object-mapper {:pretty pretty})
          println-appender (taoensso.timbre/println-appender)
-         fallback-logger (:fn println-appender)]
+         fallback-logger (:fn println-appender)
+         data-field-processor (partial process-data-map data-field-fn)]
      {:enabled? true
       :async? false
       :min-level nil
       :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context] :as data}]
             (let [;; apply context prior to resolving vargs so specific log values override context values
+                  ?err (data-field-processor ?err)
                   base-log-map (cond
                                  (and (not inline-args?) (seq context)) {:args context}
                                  (and inline-args? (seq context)) context
@@ -129,22 +148,25 @@
   `level-key`:    The key to use for log-level
   `msg-key`:      The key to use for the message (default :msg)
   `pretty`:       Pretty-print JSON
-  `inline-args?`: Place arguments on top level, instead of placing behing `args` field
-  `should-log-field-fn`: A function which determines whether to log the given top-level field.  Defaults to default-should-log-field-fn"
+  `inline-args?`: Place arguments on top level, instead of placing behind `args` field
+  `should-log-field-fn`: A function which determines whether to log the given top-level field.  Defaults to `default-should-log-field-fn`
+  `data-field-fn`: A function which pre-processes fields in the data map. Useful when map includes non-Serializable values.  Defaults to `default-data-field-fn`"
   ([]
    (install :info))
-  ([{:keys [level min-level pretty inline-args? level-key msg-key should-log-field-fn]
+  ([{:keys [level min-level pretty inline-args? level-key msg-key should-log-field-fn data-field-fn]
      :or {level-key           :level
           pretty              false
           inline-args?        true
           msg-key             :msg
-          should-log-field-fn default-should-log-field-fn}}]
+          should-log-field-fn default-should-log-field-fn
+          data-field-fn       default-data-field-fn}}]
    (timbre/set-config! {:min-level (or min-level level :info)
                         :appenders {:json (json-appender {:pretty              pretty
                                                           :inline-args?        inline-args?
                                                           :level-key           level-key
                                                           :msg-key             msg-key
-                                                          :should-log-field-fn should-log-field-fn})}})))
+                                                          :should-log-field-fn should-log-field-fn
+                                                          :data-field-fn       data-field-fn})}})))
 
 (defn log-success [request-method uri status]
   (timbre/info :method request-method :uri uri :status status))

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -1,7 +1,8 @@
 (ns timbre-json-appender.core
   (:require [jsonista.core :as json]
             [taoensso.timbre :as timbre])
-  (:import (com.fasterxml.jackson.databind SerializationFeature)))
+  (:import (com.fasterxml.jackson.databind SerializationFeature)
+           (clojure.lang ExceptionInfo)))
 
 (set! *warn-on-reflection* true)
 
@@ -71,11 +72,11 @@
     ?err
     true))
 
-(defn default-data-field-fn
+(defn default-ex-data-field-fn
   "Default function to pre-process fields in data map. This default implementation simply passes the
   field value through. A common use case might be to strip non-Serializable values from the data map.
   While exceptions with non-Serializable fields won't prevent logging, they will prevent successful
-  JSON parsing and will use the fallback logger. A data-field-fn of `(fn [f] (when (instance? Serializable f) f))`
+  JSON parsing and will use the fallback logger. An ex-data-field-fn of `(fn [f] (when (instance? Serializable f) f))`
   would replace the non-Serializable values with nils."
   [f]
   f)
@@ -88,28 +89,29 @@
   [x]
   (print (str x system-newline)) (flush))
 
-(defn- process-data-map [data-field-fn ex]
-  (when ex
-    (let [cause (process-data-map data-field-fn (ex-cause ex))]
+(defn- process-ex-data-map [ex-data-field-fn ex]
+  (if (and ex (instance? ExceptionInfo ex))
+    (let [cause (process-ex-data-map ex-data-field-fn (ex-cause ex))]
       (ex-info (ex-message ex)
-               (into {} (map (fn [[k v]] {k (data-field-fn v)}) (ex-data ex)))
-               cause))))
+               (into {} (map (fn [[k v]] {k (ex-data-field-fn v)}) (ex-data ex)))
+               cause))
+    ex))
 
 (defn json-appender
   "Creates Timbre configuration map for JSON appender"
   ([]
    (json-appender {}))
-  ([{:keys [pretty inline-args? level-key msg-key should-log-field-fn data-field-fn]
+  ([{:keys [pretty inline-args? level-key msg-key should-log-field-fn ex-data-field-fn]
      :or {pretty              false
           inline-args?        false
           level-key           :level
           msg-key             :msg
           should-log-field-fn default-should-log-field-fn
-          data-field-fn       default-data-field-fn}}]
+          ex-data-field-fn    default-ex-data-field-fn}}]
    (let [object-mapper (object-mapper {:pretty pretty})
          println-appender (taoensso.timbre/println-appender)
          fallback-logger (:fn println-appender)
-         data-field-processor (partial process-data-map data-field-fn)]
+         data-field-processor (partial process-ex-data-map ex-data-field-fn)]
      {:enabled? true
       :async? false
       :min-level nil
@@ -150,23 +152,23 @@
   `pretty`:       Pretty-print JSON
   `inline-args?`: Place arguments on top level, instead of placing behind `args` field
   `should-log-field-fn`: A function which determines whether to log the given top-level field.  Defaults to `default-should-log-field-fn`
-  `data-field-fn`: A function which pre-processes fields in the data map. Useful when map includes non-Serializable values.  Defaults to `default-data-field-fn`"
+  `ex-data-field-fn`:    A function which pre-processes fields in the data map. Useful when map includes non-Serializable values.  Defaults to `default-ex-data-field-fn`"
   ([]
    (install :info))
-  ([{:keys [level min-level pretty inline-args? level-key msg-key should-log-field-fn data-field-fn]
+  ([{:keys [level min-level pretty inline-args? level-key msg-key should-log-field-fn ex-data-field-fn]
      :or {level-key           :level
           pretty              false
           inline-args?        true
           msg-key             :msg
           should-log-field-fn default-should-log-field-fn
-          data-field-fn       default-data-field-fn}}]
+          ex-data-field-fn    default-ex-data-field-fn}}]
    (timbre/set-config! {:min-level (or min-level level :info)
                         :appenders {:json (json-appender {:pretty              pretty
                                                           :inline-args?        inline-args?
                                                           :level-key           level-key
                                                           :msg-key             msg-key
                                                           :should-log-field-fn should-log-field-fn
-                                                          :data-field-fn       data-field-fn})}})))
+                                                          :ex-data-field-fn    ex-data-field-fn})}})))
 
 (defn log-success [request-method uri status]
   (timbre/info :method request-method :uri uri :status status))

--- a/test/timbre_json_appender/core_test.clj
+++ b/test/timbre_json_appender/core_test.clj
@@ -154,7 +154,7 @@
                                     (timbre/info :a 1)))))]
         (is (= 123 (:test-context log)))))))
 
-(deftest data-field-fn
+(deftest ex-data-field-fn
   (testing "default function passes all values as they are"
     (let [log (parse-string (with-out-str
                               (timbre/with-config {:level :info
@@ -165,7 +165,7 @@
   (testing "provided function processes values in data map"
     (let [log (parse-string (with-out-str
                               (timbre/with-config {:level :info
-                                                   :appenders {:json (sut/json-appender {:data-field-fn #(when (number? %) %)})}}
+                                                   :appenders {:json (sut/json-appender {:ex-data-field-fn #(when (number? %) %)})}}
                                 (timbre/info (ex-info "plop" {:user-id 1 :name "alice"})))))]
       (is (= {:user-id 1 :name nil} (get-in log [:err :data]))))))
 

--- a/test/timbre_json_appender/core_test.clj
+++ b/test/timbre_json_appender/core_test.clj
@@ -154,6 +154,21 @@
                                     (timbre/info :a 1)))))]
         (is (= 123 (:test-context log)))))))
 
+(deftest data-field-fn
+  (testing "default function passes all values as they are"
+    (let [log (parse-string (with-out-str
+                              (timbre/with-config {:level :info
+                                                   :appenders {:json (sut/json-appender)}}
+                                (timbre/info (ex-info "plop" {:user-id 1 :name "alice"})))))]
+      (is (= {:user-id 1 :name "alice"} (get-in log [:err :data])))))
+
+  (testing "provided function processes values in data map"
+    (let [log (parse-string (with-out-str
+                              (timbre/with-config {:level :info
+                                                   :appenders {:json (sut/json-appender {:data-field-fn #(when (number? %) %)})}}
+                                (timbre/info (ex-info "plop" {:user-id 1 :name "alice"})))))]
+      (is (= {:user-id 1 :name nil} (get-in log [:err :data]))))))
+
 (deftest should-log-field-fn
   (testing "default function omits fields on non-errors"
     (let [log (parse-string (with-out-str


### PR DESCRIPTION
My team encountered a problem this week when logging exceptions including non-Serializable data in their maps. Specifically, when [clj-http](https://github.com/dakrone/clj-http) is logging an exception, it adds the `org.apache.http.impl.client.InternalHttpClient` it's using into the `:http-client` field of the `ex-info`'s data. As that class is not Serializable, it fails JSON parsing and uses the fallback logger. We still get all the log data we want, but lose the formatting and end up with many log entries instead of a singular entry.

We have a quick fix for this for ourselves - a sanitizer that walks the exception chain and filters out any non-Serializable data values - but I thought a more general purpose solution might be useful. To that end, I created this PR.

It doesn't work the same as our current solution, in that it cannot be used to filter out entries from the map; however, I think it's preferred that when logging exceptions the knowledge that _something_ was there would be better anyway.

The default behavior I provided works exactly as it does today. For the simplest sanitization, configuring the appender like this would be sufficient:
```clojure
(tas/install {:data-field-fn (fn [f] (when (instance? java.io.Serializable f) f))})
```