### PR TITLE
Timestamp opts fix

### DIFF
--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -120,7 +120,7 @@
      {:enabled? true
       :async? false
       :min-level nil
-      :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context timestamp_] :as data}]
+      :fn (fn [{:keys [level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context timestamp_] :as data}]
             (let [;; apply context prior to resolving vargs so specific log values override context values
                   ?err (data-field-processor ?err)
                   base-log-map (cond

--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -120,7 +120,7 @@
      {:enabled? true
       :async? false
       :min-level nil
-      :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context] :as data}]
+      :fn (fn [{:keys [instant level ?ns-str ?file ?line ?err vargs ?msg-fmt hostname_ context timestamp_] :as data}]
             (let [;; apply context prior to resolving vargs so specific log values override context values
                   ?err (data-field-processor ?err)
                   base-log-map (cond
@@ -133,15 +133,15 @@
                                             inline-args?
                                             msg-key)
                               ;; apply base fields last to ensure they have precedent over context and vargs
-                              (assoc :timestamp instant)
+                              (assoc :timestamp (force timestamp_))
                               (assoc level-key level)
                               (cond->
-                               (should-log-field-fn :thread data) (assoc :thread (.getName (Thread/currentThread)))
-                               (should-log-field-fn :file data) (assoc :file ?file)
-                               (should-log-field-fn :line data) (assoc :line ?line)
-                               (should-log-field-fn :ns data) (assoc :ns ?ns-str)
-                               (should-log-field-fn :hostname data) (assoc :hostname (force hostname_))
-                               ?err (assoc :err (Throwable->map ?err))))]
+                                  (should-log-field-fn :thread data) (assoc :thread (.getName (Thread/currentThread)))
+                                  (should-log-field-fn :file data) (assoc :file ?file)
+                                  (should-log-field-fn :line data) (assoc :line ?line)
+                                  (should-log-field-fn :ns data) (assoc :ns ?ns-str)
+                                  (should-log-field-fn :hostname data) (assoc :hostname (force hostname_))
+                                  ?err (assoc :err (Throwable->map ?err))))]
               (try
                 (atomic-println (json/write-value-as-string log-map object-mapper))
                 (catch Throwable _
@@ -173,7 +173,8 @@
                                                           :level-key           level-key
                                                           :msg-key             msg-key
                                                           :should-log-field-fn should-log-field-fn
-                                                          :ex-data-field-fn    ex-data-field-fn})}})))
+                                                          :ex-data-field-fn    ex-data-field-fn})}
+                        :timestamp-opts {:pattern "yyyy-MM-dd'T'HH:mm:ssX"}})))
 
 (defn log-success [request-method uri status]
   (timbre/info :method request-method :uri uri :status status))

--- a/test/timbre_json_appender/core_test.clj
+++ b/test/timbre_json_appender/core_test.clj
@@ -31,7 +31,7 @@
     (is (= 1 (:msg log)))
     (is (= 5 (-> log :args :duration)))))
 
-(deftest timestamp
+(deftest default-timestamp
   (let [log (parse-string (with-out-str (timbre/info 1 :duration 5)))]
     (is (re-find #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z" (:timestamp log)))))
 

--- a/test/timbre_json_appender/core_test.clj
+++ b/test/timbre_json_appender/core_test.clj
@@ -5,7 +5,8 @@
             [taoensso.timbre :as timbre]))
 
 (timbre/set-config! {:level :info
-                     :appenders {:json (sut/json-appender)}})
+                     :appenders {:json (sut/json-appender)}
+                     :timestamp-opts {:pattern "yyyy-MM-dd'T'HH:mm:ssX"}})
 
 (def object-mapper (json/object-mapper {:decode-key-fn true}))
 
@@ -29,6 +30,19 @@
   (let [log (parse-string (with-out-str (timbre/info 1 :duration 5)))]
     (is (= 1 (:msg log)))
     (is (= 5 (-> log :args :duration)))))
+
+(deftest timestamp
+  (let [log (parse-string (with-out-str (timbre/info 1 :duration 5)))]
+    (is (re-find #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z" (:timestamp log)))))
+
+(deftest changing-timestamp-pattern
+  (let [old-config timbre/*config*]
+    (try
+      (timbre/merge-config! {:timestamp-opts {:pattern "yyyy-MM-dd'T'HH:mm:ss.SSSX"}})
+      (let [log (parse-string (with-out-str (timbre/info 1 :duration 5)))]
+        (is (re-find #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z" (:timestamp log))))
+      (finally
+        (timbre/set-config! old-config)))))
 
 (deftest message-and-map
   (let [log (parse-string (with-out-str (timbre/info "Task done" {:duration 5


### PR DESCRIPTION
This is a fix for issue #24 

The issue was caused by using instant instead of timestamp_ on the appender.

I have changed the function install to pass exactly the same pattern as it was used by default, so there should be no change for anyone.

Added a couple of tests to verify the behaviour.