### PR TITLE
Bump jsonista due to CVE-2020-36518

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {metosin/jsonista {:mvn/version "0.3.1"}
+ :deps {metosin/jsonista {:mvn/version "0.3.6"}
         com.taoensso/timbre {:mvn/version "5.1.2"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.829"}}}


### PR DESCRIPTION
jsonista dependency jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
https://nvd.nist.gov/vuln/detail/CVE-2020-36518