### PR TITLE
Update jackson to remediate CVE-2022-42003

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .nrepl-port
 target
 .clj-kondo/.cache
+.lsp

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ nil
 
 # Changelog
 
+2023-09-29 (0.2.9)
+
+- Bump jsonista due to CVE-2022-42003
+
 2022-09-21 (0.2.8)
 * Keep original stack trace of ExceptionInfo
   * While making sure the data of an ExceptionInfo is serializable, we re-create the ExceptionInfo instance. Now the original stack trace is also set to the newly created ExceptionInfo.

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
- :deps {metosin/jsonista {:mvn/version "0.3.6"}
-        com.taoensso/timbre {:mvn/version "5.1.2"}}
+ :deps {metosin/jsonista {:mvn/version "0.3.8"}
+        com.taoensso/timbre {:mvn/version "6.3.1"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.829"}}}
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}}}
            :pack {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
-                                                :sha "110ca11f853fa9dbb3f8eadba3c4176311bae4ac"}}
+                                                :sha "9ae4f8ff34427d0549fd5c58c0353e54523b3dfa"}}
                   :main-opts ["-m"]}}}


### PR DESCRIPTION
Update jsonista to remedy CVE-2022-42003 and the rest to be up to date.