### PR TITLE
Switch 0-arg install call to recurse with nil

### DIFF
--- a/src/timbre_json_appender/core.clj
+++ b/src/timbre_json_appender/core.clj
@@ -198,7 +198,7 @@
   `ex-data-field-fn`:    A function which pre-processes fields in the ex-info data map. Useful when ex-info data map includes non-Serializable values. Defaults to `default-ex-data-field-fn`
   `key-names`: Map of log key names. Can be used to override the default key names in `default-key-names`"
   ([]
-   (install :info))
+   (install nil))
   ([{:keys [level min-level pretty inline-args? level-key msg-key should-log-field-fn ex-data-field-fn key-names]
      :or {level-key           :level
           pretty              false


### PR DESCRIPTION
`(install :info)` doesn't do anything (no errors are thrown, the keyword is ignored), but it seems wise to either choose to pass in `{:min-level :info}` or `nil`. I went with `nil` given that you're already calling `(or min-level level :info)` in the main body of `install`.